### PR TITLE
Update python_version for 3.13

### DIFF
--- a/abnormalsecurity.json
+++ b/abnormalsecurity.json
@@ -7,7 +7,7 @@
     "logo": "logo_abnormalsecurity.svg",
     "logo_dark": "logo_abnormalsecurity_dark.svg",
     "product_name": "Abnormal Security",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": false,
     "product_version_regex": ".*",
     "publisher": "Splunk",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)