### PR TITLE
Fix python_version format

### DIFF
--- a/abnormalsecurity.json
+++ b/abnormalsecurity.json
@@ -7,10 +7,7 @@
     "logo": "logo_abnormalsecurity.svg",
     "logo_dark": "logo_abnormalsecurity_dark.svg",
     "product_name": "Abnormal Security",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": false,
     "product_version_regex": ".*",
     "publisher": "Splunk",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)